### PR TITLE
inserção de nome de usuário de e-mail

### DIFF
--- a/SetupOrion
+++ b/SetupOrion
@@ -2688,19 +2688,23 @@ preencha_as_info
 
 while true; do
 
-echo -e "\e[97mPasso$amarelo 1/4\e[0m"
-echo -en "\e[33mDigite o Email: \e[0m" && read -r email_teste
+echo -e "\e[97mPasso$amarelo 1/5\e[0m"
+echo -en "\e[33mDigite o endereço de Email: \e[0m" && read -r email_teste
 echo ""
 
-echo -e "\e[97mPasso$amarelo 2/4\e[0m"
+echo -e "\e[97mPasso$amarelo 2/5\e[0m"
+echo -en "\e[33mDigite o usuário de Email: \e[0m" && read -r user_teste
+echo ""
+
+echo -e "\e[97mPasso$amarelo 3/5\e[0m"
 echo -en "\e[33mDigite a Senha do email: \e[0m" && read -r senha_teste
 echo ""
 
-echo -e "\e[97mPasso$amarelo 3/4\e[0m"
+echo -e "\e[97mPasso$amarelo 4/5\e[0m"
 echo -en "\e[33mDigite o Host Smtp: \e[0m" && read -r host_teste
 echo ""
 
-echo -e "\e[97mPasso$amarelo 4/4\e[0m"
+echo -e "\e[97mPasso$amarelo 5/5\e[0m"
 echo -en "\e[33mDigite a Porta Smtp: \e[0m" && read -r porta_teste
 echo ""
 
@@ -2709,6 +2713,9 @@ nome_testeemail
 conferindo_as_info
 
 echo -e "\e[33mEmail:\e[97m $email_teste\e[0m"
+echo ""
+
+echo -e "\e[33mUsuário:\e[97m $user_teste\e[0m"
 echo ""
 
 echo -e "\e[33mSenha:\e[97m $senha_teste\e[0m"
@@ -2742,7 +2749,7 @@ sudo apt-get install swaks -y > /dev/null 2>&1
 msg="Se você está lendo isso, o seu SMTP está funcionando =D.
 By: OrionDesign"
 
-if swaks --to "$email_teste" --from "$email_teste" --server "$host_teste" --port "$porta_teste" --auth LOGIN --auth-user "$email_teste" --auth-password "$senha_teste" --tls --body "$msg"; then
+if swaks --to "$email_teste" --from "$email_teste" --server "$host_teste" --port "$porta_teste" --auth LOGIN --auth-user "$user_teste" --auth-password "$senha_teste" --tls --body "$msg"; then
     sleep 2
     clear
     nome_testeemail
@@ -5306,38 +5313,43 @@ preencha_as_info
 while true; do
 
     ##Pergunta o Dominio do Builder
-    echo -e "\e[97mPasso$amarelo 1/9\e[0m"
+    echo -e "\e[97mPasso$amarelo 1/10\e[0m"
     echo -en "\e[33mDigite o Dominio para o Builder do Typebot (ex: typebot.oriondesign.art.br): \e[0m" && read -r url_typebot
     echo ""
 
     ##Pergunta o Dominio do Viewer
-    echo -e "\e[97mPasso$amarelo 2/9\e[0m"
+    echo -e "\e[97mPasso$amarelo 2/10\e[0m"
     echo -en "\e[33mDigite o Dominio para o Viewer do Typebot (ex: bot.oriondesign.art.br): \e[0m" && read -r url_viewer
     echo ""
 
     ##Pergunta a versão da ferramenta
-    echo -e "\e[97mPasso$amarelo 3/9\e[0m"
+    echo -e "\e[97mPasso$amarelo 3/10\e[0m"
     echo -en "\e[33mDigite a versão que deseja do Typebot (ex: 2.21.3 ou latest): \e[0m" && read -r versao_typebot
     echo ""
 
     ##Pergunta o Email SMTP
-    echo -e "\e[97mPasso$amarelo 4/9\e[0m"
+    echo -e "\e[97mPasso$amarelo 4/109\e[0m"
     echo -en "\e[33mDigite o Email para SMTP (ex: contato@oriondesign.art.br): \e[0m" && read -r email_typebot
+    echo ""
+
+    ##Pergunta o usuário do Email SMTP
+    echo -e "\e[97mPasso$amarelo 5/10\e[0m"
+    echo -en "\e[33mDigite o Usuário para SMTP (ex: contato@oriondesign.art.br): \e[0m" && read -r usuario_email_typebot
     echo ""
     
     ## Pergunta a senha do SMTP
-    echo -e "\e[97mPasso$amarelo 5/9\e[0m"
+    echo -e "\e[97mPasso$amarelo 6/10\e[0m"
     echo -e "$amarelo--> Sem caracteres especiais: \!#$ | Se estiver usando gmail use a senha de app"
     echo -en "\e[33mDigite a Senha SMTP do Email (ex: @Senha123_): \e[0m" && read -r senha_email_typebot
     echo ""
 
     ## Pergunta o Host SMTP do email
-    echo -e "\e[97mPasso$amarelo 6/9\e[0m"
+    echo -e "\e[97mPasso$amarelo 7/10\e[0m"
     echo -en "\e[33mDigite o Host SMTP do Email (ex: smtp.hostinger.com): \e[0m" && read -r smtp_email_typebot
     echo ""
 
     ## Pergunta a porta SMTP do email
-    echo -e "\e[97mPasso$amarelo 7/9\e[0m"
+    echo -e "\e[97mPasso$amarelo 8/10\e[0m"
     echo -en "\e[33mDigite a porta SMTP do Email (ex: 465): \e[0m" && read -r porta_smtp_typebot
     echo ""
 
@@ -5349,12 +5361,12 @@ while true; do
     fi
 
     ## Pergunta qual é o Access Key do minio
-    echo -e "\e[97mPasso$amarelo 8/9\e[0m"
+    echo -e "\e[97mPasso$amarelo 9/10\e[0m"
     echo -en "\e[33mAccess Key Minio: \e[0m" && read -r S3_ACCESS_KEY
     echo ""
 
     ## Pergunta qual é a Secret Key do minio
-    echo -e "\e[97mPasso$amarelo 9/9\e[0m"
+    echo -e "\e[97mPasso$amarelo 10/10\e[0m"
     echo -en "\e[33mSecret Key Minio: \e[0m" && read -r S3_SECRET_KEY
     echo ""
 
@@ -5381,6 +5393,10 @@ while true; do
 
     ## Informação sobre Email
     echo -e "\e[33mEmail do SMTP:\e[97m $email_typebot\e[0m"
+    echo ""
+
+    ## Informação sobre Email
+    echo -e "\e[33mUsuário do SMTP:\e[97m $usuario_email_typebot\e[0m"
     echo ""
 
     ## Informação sobre Senha do Email
@@ -5520,7 +5536,7 @@ services:
       - ADMIN_EMAIL=$email_typebot ## Email SMTP
       - NEXT_PUBLIC_SMTP_FROM='Suporte' <$email_typebot>
       - SMTP_AUTH_DISABLED=false
-      - SMTP_USERNAME=$email_typebot
+      - SMTP_USERNAME=$usuario_email_typebot
       - SMTP_PASSWORD=$senha_email_typebot
       - SMTP_HOST=$smtp_email_typebot
       - SMTP_PORT=$porta_smtp_typebot
@@ -5585,7 +5601,7 @@ services:
       - ADMIN_EMAIL=$email_typebot ## Email SMTP
       - NEXT_PUBLIC_SMTP_FROM='Suporte' <$email_typebot>
       - SMTP_AUTH_DISABLED=false
-      - SMTP_USERNAME=$email_typebot
+      - SMTP_USERNAME=$usuario_email_typebot
       - SMTP_PASSWORD=$senha_email_typebot
       - SMTP_HOST=$smtp_email_typebot
       - SMTP_PORT=$porta_smtp_typebot


### PR DESCRIPTION
Esse PR implementa a possibilidade de se ter um teste e o TypeBot com um endereço de e-mail de envio diferente do endereço de e-mail do login do SMTP.
Foi testado e validado localmente e em servidor Ubuntu.