### PR TITLE
Corrigir erro 404 page not found quando o wordpress tem www

### DIFF
--- a/SetupOrion
+++ b/SetupOrion
@@ -8311,7 +8311,7 @@ services:
           - node.role == manager
       labels:
         - traefik.enable=true
-        - traefik.http.routers.$nome_do_servico_wordpress.rule=Host(\`$url_wordpress\`)
+        - traefik.http.routers.$nome_do_servico_wordpress.rule=Host(\`$url_wordpress, www.$url_wordpress\`)
         - traefik.http.routers.$nome_do_servico_wordpress.entrypoints=websecure
         - traefik.http.routers.$nome_do_servico_wordpress.tls.certresolver=letsencryptresolver
         - traefik.http.routers.$nome_do_servico_wordpress.service=$nome_do_servico_wordpress


### PR DESCRIPTION
Quando se acessa um wordpress com dominio principal com o www, exemplo: www.oriondesign.art.br ele dá erro 404 page not found, já isso não acontece quando acessa sem o www.

