### PR TITLE
fix: Update SetupOrion

### DIFF
--- a/SetupOrion
+++ b/SetupOrion
@@ -3429,13 +3429,14 @@ services:
 ## --------------------------- ORION --------------------------- ##
 
   traefik:
-    image: traefik:v2.11.2
+    image: traefik:v3.4.0
     command:
       - "--api.dashboard=true"
-      - "--providers.docker.swarmMode=true"
+      - "--providers.swarm=true" # ✅ Novo nome a partir da v3 (substitui 'providers.docker.swarmMode')
+      # - "--providers.docker.swarmMode=true" # ❌ Obsoleto em Traefik v3.x
       - "--providers.docker.endpoint=unix:///var/run/docker.sock"
       - "--providers.docker.exposedbydefault=false"
-      - "--providers.docker.network=$nome_rede_interna" ## Nome da rede interna
+      - "--providers.docker.network=$nome_rede_interna" # ✅ Rede usada pelo Traefik no Swarm
       - "--entrypoints.web.address=:80"
       - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
       - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
@@ -3565,7 +3566,7 @@ services:
     command: -H tcp://tasks.agent:9001 --tlsskipverify
 
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      #- /var/run/docker.sock:/var/run/docker.sock # não precisa pois ele já se comunica com o agent pela rede interna
       - portainer_data:/data
 
     networks:


### PR DESCRIPTION
* Traefik v2 já esta obsoleto e com este ajuste possível usar v3 (3.4.0)
* Removido o volume /var/run/docker.sock:/var/run/docker.sock do portainer, pois ele já se comunica com o agent pela rede interna, e a exposição do docker.sock no portainer não é necessária.