### PR TITLE
Corrigindo a imagem do Wuzapi usada no comando pull

### DIFF
--- a/SetupOrion
+++ b/SetupOrion
@@ -27719,7 +27719,7 @@ echo ""
 sleep 1
 
 ## Baixando imagens:
-pull ruben18salazar/wuzapi:api
+pull asternic/wuzapi:latest
 
 ## Usa o serviço wait_wuzapi para verificar se o serviço esta online
 wait_stack wuzapi${1:+_$1}_wuzapi${1:+_$1}


### PR DESCRIPTION
O comando pull da instalação do Wuzapi estava baixando uma outra imagem do Wuzapi  (diferente da stack) para a VPS.