### PR TITLE
Ajuste Comando Chatwoot Oficial

### DIFF
--- a/SetupOrion
+++ b/SetupOrion
@@ -5240,7 +5240,7 @@ services:
 
   chatwoot${1:+_$1}_app:
     image: chatwoot/chatwoot:v4.1.0 ## Versão do Chatwoot
-    command: bundle exec rails s -p 3000 -b 0.0.0.0
+    command: sh -c 'bundle exec rails db:chatwoot_prepare && bundle exec rails s -p 3000 -b 0.0.0.0'
     entrypoint: docker/entrypoints/rails.sh
 
     volumes:


### PR DESCRIPTION
Esta ajuste permite que quando atualizar chatwoot, não precise executar comando para update do banco.