### PR TITLE
fix: Atualiza comando do serviço Chatwoot para incluir configuração do processador de variantes do Active Storage

### DIFF
--- a/SetupOrion
+++ b/SetupOrion
@@ -5239,7 +5239,8 @@ services:
 
   chatwoot${1:+_$1}_app:
     image: chatwoot/chatwoot:v4.1.0 ## Versão do Chatwoot
-    command: bundle exec rails s -p 3000 -b 0.0.0.0
+    command: >
+      sh -c "echo 'Rails.application.config.active_storage.variant_processor = :mini_magick' > /app/config/initializers/active_storage.rb && bundle exec rails s -p 3000 -b 0.0.0.0"
     entrypoint: docker/entrypoints/rails.sh
 
     volumes:


### PR DESCRIPTION
fix: Atualiza comando do serviço Chatwoot para incluir configuração do processador de variantes do Active Storage

- Adiciona configuração para forçar o uso do MiniMagick como processador de variantes
- Resolve problema de avatares do WhatsApp aparecendo em escala de cinza (efeito "x-ray")
- Garante que imagens de perfil sejam renderizadas em cores corretas
- Evita erros de UnsupportedImageProcessingMethod no Rails 7

A solução implementada é baseada na issue #10863 do repositório oficial do Chatwoot:
https://github.com/chatwoot/chatwoot/issues/10863

O problema ocorria porque:
- Avatares do WhatsApp às vezes possuem metadados de cor incomuns
- Rails 7 usa Vips como processador padrão do ActiveStorage
- Vips interpretava incorretamente o perfil de cor das imagens

A correção força o uso do MiniMagick que processa as transformações de imagem de forma mais consistente e não converte imagens para escala de cinza inesperadamente.

Refs: [Issue Chatwoot #10863](https://github.com/chatwoot/chatwoot/issues/10863)