### PR TITLE
fix: adiciona comando de execução de migration no command do chatwoot

### DIFF
--- a/SetupOrion
+++ b/SetupOrion
@@ -5240,7 +5240,7 @@ services:
   chatwoot${1:+_$1}_app:
     image: chatwoot/chatwoot:v4.1.0 ## Versão do Chatwoot
     command: >
-      sh -c "echo 'Rails.application.config.active_storage.variant_processor = :mini_magick' > /app/config/initializers/active_storage.rb && bundle exec rails s -p 3000 -b 0.0.0.0"
+      sh -c "echo 'Rails.application.config.active_storage.variant_processor = :mini_magick' > /app/config/initializers/active_storage.rb && bundle exec rails db:chatwoot_prepare && bundle exec rails s -p 3000 -b 0.0.0.0"
     entrypoint: docker/entrypoints/rails.sh
 
     volumes:


### PR DESCRIPTION
Esse PR atualiza o command do chatwoot, adicionei um comando extra pra ele aplicar a migration e não da erro no modelo de account quando alguém atualizar da versão 4.2 em diante.