### PR TITLE
Ao tentar atualizar a stack do N8N o serviço falha no momento de exec…

### DIFF
--- a/SetupOrion
+++ b/SetupOrion
@@ -8169,6 +8169,7 @@ services:
 
     environment:
       ## 🗄️ Banco de Dados (PostgreSQL)
+      - N8N_FIX_MIGRATIONS=true 
       - DB_TYPE=postgresdb
       - DB_POSTGRESDB_DATABASE=n8n_queue${1:+_$1}
       - DB_POSTGRESDB_HOST=postgres
@@ -8264,6 +8265,7 @@ services:
 
     environment:
       ## 🗄️ Banco de Dados (PostgreSQL)
+      - N8N_FIX_MIGRATIONS=true 
       - DB_TYPE=postgresdb
       - DB_POSTGRESDB_DATABASE=n8n_queue${1:+_$1}
       - DB_POSTGRESDB_HOST=postgres
@@ -8359,6 +8361,7 @@ services:
 
     environment:
       ## 🗄️ Banco de Dados (PostgreSQL)
+      - N8N_FIX_MIGRATIONS=true 
       - DB_TYPE=postgresdb
       - DB_POSTGRESDB_DATABASE=n8n_queue${1:+_$1}
       - DB_POSTGRESDB_HOST=postgres
@@ -33402,6 +33405,7 @@ services:
 
     environment:
       ## 🗄️ Banco de Dados (PostgreSQL)
+      - N8N_FIX_MIGRATIONS=true 
       - DB_TYPE=postgresdb
       - DB_POSTGRESDB_DATABASE=n8n_queue${1:+_$1}
       - DB_POSTGRESDB_HOST=postgres


### PR DESCRIPTION
### O motivo

Esta PR introduz uma única variável de ambiente, `N8N_FIX_MIGRATIONS=true`, nas diversas definições do serviço do `N8N` no `SetupOrion` para garantir um tratamento de migração para o serviço.


### A causa

O problema ocorre ao tentar atualizar a stack do N8N no portainer e o serviço falha no momento de execução das migrations, causando indiposnibilidade, a solução é fazer um fix nas migrations colocando a flag `N8N_FIX_MIGRATION` para true.

#### O log coletado:

```shell
Initializing n8n process

n8n ready on ::, port 5678

Migrations in progress, please do NOT stop the process.

Starting migration DropRoleMapping1705429061930

Migration "DropRoleMapping1705429061930" failed, error: column "role" of relation "user" already exists

There was an error running database migrations

column "role" of relation "user" already exists
```


### As mudanças:

* Adicionado `N8N_FIX_MIGRATIONS=true` à seção `environment` das seguintes definições de serviço do `SetupOrion`: [[1]](diffhunk://#diff-d5681b3413639a9ca82456faa8b54051c319c289c0bd3657e2c5506c410b7804R8172) [[2]](diffhunk://#diff-d5681b3413639a9ca82456faa8b54051c319c289c0bd3657e2c5506c410b7804R8268) [[3]](diffhunk://#diff-d5681b3413639a9ca82456faa8b54051c319c289c0bd3657e2c5506c410b7804R8364) [[4]](diffhunk://#diff-d5681b3413639a9ca82456faa8b54051c319c289c0bd3657e2c5506c410b7804R33408)