### PR TITLE
Ajuste para aceitar Debian 13

### DIFF
--- a/Setup
+++ b/Setup
@@ -258,12 +258,13 @@ fi
 
 echo ""
 
-## Instalando neofetch
-apt install neofetch -y > /dev/null 2>&1
-if [ $? -eq 0 ]; then
+## Instalando neofetch ou fastfetch
+if apt install neofetch -y > /dev/null 2>&1; then
     echo "13/14 - [ OK ] - Verificando/Instalando neofetch"
+elif apt install fastfetch -y > /dev/null 2>&1; then
+    echo "13/14 - [ OK ] - Verificando/Instalando fastfetch"
 else
-    echo "13/14 - [ OFF ] - Verificando/Instalando neofetch"
+    echo "13/14 - [ OFF ] - Não foi possível instalar neofetch nem fastfetch"
 fi
 
 echo ""


### PR DESCRIPTION
Este ajuste tentar instalar neofetch (Debian 11) e, se falhar, instalar fastfetch (Debian 13)

Primeiro tenta instalar neofetch (Debian 11/anteriores).

Se falhar, tenta instalar fastfetch (Debian 13 e superiores).

Se nenhum instalar, avisa no log.