### PR TITLE
fix(evocrm): pin ClickHouse 26.3.20.7 — latest >= 26.6 exige AVX2 e crasha em CPUs antigas (Xeon E3 v2/Ivy Bridge)

### DIFF
--- a/SetupOrion
+++ b/SetupOrion
@@ -42251,7 +42251,10 @@ services:
   ## ClickHouse — storage dos eventos do EvoFlow (STORAGE_MODE=clickhouse).
   ## Sem portas publicadas: só a rede interna alcança.
   evocrm${1:+_$1}_clickhouse:
-    image: clickhouse/clickhouse-server:latest  ## Versão do ClickHouse
+    ## PINADO: desde a 26.6 o build padrao do ClickHouse exige AVX2 (x86-64-v3)
+    ## e morre com "Illegal instruction" em CPUs antigas (ex: Xeon E3 v2/Ivy Bridge).
+    ## 26.3 LTS e a ultima linha compativel com x86-64-v2 (SSE4.2).
+    image: clickhouse/clickhouse-server:26.3.20.7  ## Versão do ClickHouse
 
     environment:
       - CLICKHOUSE_USER=default
@@ -42439,7 +42442,7 @@ echo -e "\e[33m--> A tela pode parecer travada durante o download. Isso é norma
 echo ""
 
 ## Baixando imagens:
-pull redis:latest clickhouse/clickhouse-server:latest rabbitmq:3-alpine evoapicloud/evo-auth-service-community:latest evoapicloud/evo-ai-core-service-community:latest evoapicloud/evo-ai-processor-community:latest evoapicloud/evo-bot-runtime:latest evoapicloud/evo-ai-crm-community:latest evoapicloud/evo-flow-community:latest evoapicloud/evo-crm-gateway:latest evoapicloud/evo-ai-frontend-community:latest
+pull redis:latest clickhouse/clickhouse-server:26.3.20.7 rabbitmq:3-alpine evoapicloud/evo-auth-service-community:latest evoapicloud/evo-ai-core-service-community:latest evoapicloud/evo-ai-processor-community:latest evoapicloud/evo-bot-runtime:latest evoapicloud/evo-ai-crm-community:latest evoapicloud/evo-flow-community:latest evoapicloud/evo-crm-gateway:latest evoapicloud/evo-ai-frontend-community:latest
 
 ## Usa o serviço wait_EVOCRM para verificar se o serviço esta online
 wait_stack evocrm${1:+_$1}_evocrm${1:+_$1}_redis evocrm${1:+_$1}_evocrm${1:+_$1}_clickhouse evocrm${1:+_$1}_evocrm${1:+_$1}_rabbitmq evocrm${1:+_$1}_evocrm${1:+_$1}_auth evocrm${1:+_$1}_evocrm${1:+_$1}_auth_sidekiq evocrm${1:+_$1}_evocrm${1:+_$1}_core evocrm${1:+_$1}_evocrm${1:+_$1}_processor evocrm${1:+_$1}_evocrm${1:+_$1}_bot_runtime evocrm${1:+_$1}_evocrm${1:+_$1}_crm evocrm${1:+_$1}_evocrm${1:+_$1}_crm_sidekiq evocrm${1:+_$1}_evocrm${1:+_$1}_evoflow evocrm${1:+_$1}_evocrm${1:+_$1}_gateway evocrm${1:+_$1}_evocrm${1:+_$1}_frontend


### PR DESCRIPTION
## Resumo
Desde o release 26.6 (jun/2026) o build padrão do ClickHouse passou a alvo **x86-64-v3 (AVX2)** em vez de x86-64-v2 (SSE4.2). Em hosts sem AVX2 (ex: `Intel Xeon E3-12xx v2 / Ivy Bridge`, comum em VPS baratas), o container `evocrm_clickhouse` morre em loop com `exit 132` — `Illegal instruction (core dumped)` — e o `evoflow` fica preso em `Waiting for clickhouse...`.

## Solução
Pin da imagem em **`clickhouse/clickhouse-server:26.3.20.7`** (última linha 26.3 LTS, compatível com x86-64-v2 / SSE4.2). O mesmo padrão já usado no instalador standalone do ClickHouse dentro do script (`23.8.8.20-alpine`).

## Arquivos alterados
- `SetupOrion` linha ~42254: `image: clickhouse/clickhouse-server:latest` → `26.3.20.7` (com comentário explicativo)
- `SetupOrion` linha ~42442: `pull` command atualizado

## Testado
- Deploy na VPS `69.197.142.186` (Xeon E3-12xx v2, apenas AVX + SSE4.2)
- `evocrm_clickhouse` subiu healthy (`Ready`, sem SIGILL)
- `evoflow` conectou e iniciou: `Nest application successfully started`
- Stack completa: 17/17 serviços `1/1`

## Referência
ClickHouse 26.6 changelog: *"The default x86 build now targets x86-64-v3 (AVX2) instead of x86-64-v2 (SSE4.2). If your CPU does not support AVX2, use the \`amd64compat\` build."*
PR upstream: https://github.com/ClickHouse/ClickHouse/pull/105019